### PR TITLE
Show clear error when no authorization is found when the RFID card of the user is scanned

### DIFF
--- a/api/v1/juliana.py
+++ b/api/v1/juliana.py
@@ -59,6 +59,9 @@ def juliana_rfid_get(request, event_id, rfid):
     user = card.user
     authorization = Authorization.get_for_user_event(user, event)
 
+    if not authorization:
+        raise InvalidParamsError('No authorization found for user')
+
     res = {
         'user': {
             'id': user.pk,


### PR DESCRIPTION
Previously, an OtherError happened because the code did not explicitly check for a None value.