### PR TITLE
API improvements

### DIFF
--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -1,1 +1,1 @@
-from . import api, authorization, billing, juliana, organization, rfid, user
+from . import api, authorization, billing, event, juliana, organization, rfid, user

--- a/api/v1/billing.py
+++ b/api/v1/billing.py
@@ -1,24 +1,26 @@
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from jsonrpc import jsonrpc_method
 
 from .common import api_v1_site, format_order
 from .exceptions import NotFoundError
 from apps.billing.models import Order
+from apps.organization.models import Organization
 from utils.auth.decorators import manager_required
 
 
-@jsonrpc_method('order.unsynchronized(unused=Number) -> Array', site=api_v1_site, safe=True, authenticated=True)
+@jsonrpc_method('order.unsynchronized(organizations=Array) -> Array', site=api_v1_site, safe=True, authenticated=True)
 @manager_required
-def order_unsynchronized(request, unused):
+def order_unsynchronized(request, organizations=None):
     """
     Return a list of unsynchronized orders.
 
     Required user level: Manager
 
-    Requires an unused parameter because of a competability issue between the
-    jsonrpc server en jsonrpclib client.
-
     Returns a list of Order objects.
+
+    organizations -- List of slugs of organizations for which unsynchronized
+    orders are retrieved. Authenticated user must be a manager in each organization.
 
     Example return value:
     [
@@ -81,8 +83,16 @@ def order_unsynchronized(request, unused):
         }
     ]
     """
+    if organizations is None:
+        organizations_objects = [request.organization]
+    else:
+        organizations_objects = Organization.objects.filter(slug__in=organizations)
+        for organization in organizations_objects:
+            if not request.user.profile.is_manager(organization):
+                raise PermissionDenied
+
     result = []
-    orders = Order.objects.filter(authorization__organization=request.organization, synchronized=False)
+    orders = Order.objects.filter(authorization__organization__in=organizations_objects, synchronized=False)
 
     orders = orders.select_related('authorization__user', 'event').prefetch_related('purchases__product')
 

--- a/api/v1/common.py
+++ b/api/v1/common.py
@@ -14,10 +14,49 @@ def format_authorization(authorization):
     }
 
 
+def format_location(location):
+    """
+    :type location: apps.organization.models.Location
+    """
+    return {
+        'id': location.pk,
+        'name': location.name
+    }
+
+
 def format_event(event):
+    """
+    :type event: apps.scheduling.models.Event
+    """
+    return {
+        'id': event.pk,
+        'name': event.name
+    }
+
+
+def format_event_extended(event):
+    """
+    :type event: apps.scheduling.models.Event
+    """
     return {
         'id': event.pk,
         'name': event.name,
+        'organizer': format_organization(event.organizer),
+        'participants': [format_organization(x) for x in event.participants.all()],
+        'locations': [format_location(x) for x in event.location.all()],
+        'starts_at': event.starts_at.isoformat(),
+        'ends_at': event.ends_at.isoformat()
+    }
+
+
+
+def format_organization(organization):
+    """
+    :type organization: apps.organization.models.Organization
+    """
+    return {
+        'slug': organization.slug,
+        'name': organization.name
     }
 
 

--- a/api/v1/event.py
+++ b/api/v1/event.py
@@ -1,21 +1,36 @@
 from datetime import timedelta, datetime
 
+from django.core.exceptions import PermissionDenied
 from django.forms.models import model_to_dict
 from jsonrpc import jsonrpc_method
 
 from .common import api_v1_site, format_event_extended
-from apps.organization.models import Location
+from apps.organization.models import Location, Organization
 from apps.scheduling.models import Event, StandardReservation
 
 
-@jsonrpc_method('event.list(String, String, String, String) -> Array', site=api_v1_site, safe=True, authenticated=True)
-def event_list(request, start_date, start_time, end_date, end_time):
+@jsonrpc_method('event.list(String, String, String, String, Boolean, Array) -> Array', site=api_v1_site, safe=True, authenticated=True)
+def event_list(request, start_date, start_time, end_date, end_time, only_unsynchronized=False, organizations=None):
     """Returns all events in the specified time span"""
 
     start = datetime.strptime("%s %s" % (start_date, start_time), "%Y-%m-%d %H:%M")
     end = datetime.strptime("%s %s" % (end_date, end_time), "%Y-%m-%d %H:%M")
 
     events = Event.objects.filter(starts_at__gte=start, ends_at__lte=end)
+
+    organizations_objects = Organization.objects.filter(slug__in=organizations) if organizations is not None else None
+    if organizations is not None:
+        events = events.filter(organizer__in=organizations_objects)
+
+    if only_unsynchronized:
+        if organizations is None:
+            raise NotImplementedError("Please specify organizations when requesting unsynchronized events")
+        for organization in organizations_objects:
+            if not request.user.profile.is_manager(organization):
+                raise PermissionDenied
+
+        events = events.filter(orders__synchronized=0).distinct()
+
     events.select_related('organizer').prefetch_related('participants', 'location')
     return [format_event_extended(event) for event in events]
 


### PR DESCRIPTION
Some API improvements I needed to integrate Alexia with the system currently in use at Arago:

* Drop usage of the current organization in the order module, and switch to explicit specification of organizations where needed. Because I need to synchronize orders for two organizations the stateful API design was a pain to use (constantly need to switch the active organization).
* Add method to get a list of all unsynchronised events with some more details.