### PR TITLE
Auto-merge receipt items for the same product

### DIFF
--- a/assets/css/juliana.css
+++ b/assets/css/juliana.css
@@ -1,3 +1,8 @@
+@keyframes flash-receipt {
+    from { box-shadow: 0 0 15px 0px #5BC0DE; }
+    to { box-shadow: 0 0 0px 0px #5BC0DE; }
+}
+
 body {
   padding-top: 20px!important;
 }
@@ -88,6 +93,12 @@ body {
 
 #receipt-table, #log-table {
 	width: 100%;
+}
+
+#receipt-table tr.flash {
+    animation-name: flash-receipt;
+    animation-duration: 0.2s;
+    animation-timing-function: linear;
 }
 
 #receipt-table td {

--- a/assets/js/juliana.js
+++ b/assets/js/juliana.js
@@ -178,11 +178,11 @@ Receipt = {
         }
 
         this.updateTotalAmount();
-        this.updateReceipt();
+        this.updateReceipt(product);
 
         Display.set('OK');
     },
-    updateReceipt: function() {
+    updateReceipt: function(flash) {
         $('#receipt-table').empty();
         for (var i in this.receipt) {
             if (this.receipt[i]===undefined) continue;
@@ -194,7 +194,9 @@ Receipt = {
 
             var price = ((quantity * Settings.products[product].price) / 100).toFixed(2);
 
-            $('#receipt-table').append('<tr data-pid="' + i + '"><td width="70%"><a onclick="Receipt.remove($(this).data(\'pid\'));" class="btn btn-danger command" href="#" data-pid="' + i + '">X</a><span>' + desc + '</span></td><td>€' + price + '</td></tr>');
+            var doFlash = (flash!==undefined && flash==product)?' class="flash"':'';
+
+            $('#receipt-table').append('<tr' + doFlash + ' data-pid="' + i + '"><td width="70%"><a onclick="Receipt.remove($(this).data(\'pid\'));" class="btn btn-danger command" href="#" data-pid="' + i + '">X</a><span>' + desc + '</span></td><td>€' + price + '</td></tr>');
         }
     },
     remove: function (index) {


### PR DESCRIPTION
This allows tapping a button twice, and still show only one receipt
item, but now with quantity 2.

The Receipt.getReceipt() functions is not needed anymore, because the
Receipt.receipt variable is always 'clean' now.