### PR TITLE
Soft deletion for RFID cards and events

### DIFF
--- a/apps/billing/managers.py
+++ b/apps/billing/managers.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+
+class PermanentProductManager(models.Manager):
+    """Provides several extra handy methods to find events."""
+    def get_queryset(self):
+        return super(PermanentProductManager, self).get_queryset().filter(deleted=False)
+
+
+class TemporaryProductManager(models.Manager):
+    """Provides several extra handy methods to find events."""
+    def get_queryset(self):
+        return super(TemporaryProductManager, self).get_queryset().filter(deleted=False)

--- a/apps/billing/migrations/0012_product_deleted.py
+++ b/apps/billing/migrations/0012_product_deleted.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('billing', '0011_alter_order_purchase'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='product',
+            name='deleted',
+            field=models.BooleanField(default=False, verbose_name='deleted'),
+        ),
+    ]

--- a/apps/billing/migrations/0013_auto_20151223_1526.py
+++ b/apps/billing/migrations/0013_auto_20151223_1526.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('billing', '0012_product_deleted'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='permanentproduct',
+            name='productgroup',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, verbose_name='product group', to='billing.ProductGroup', null=True),
+        ),
+    ]

--- a/apps/billing/models.py
+++ b/apps/billing/models.py
@@ -161,7 +161,7 @@ class PermanentProduct(Product):
     stockproduct -- If - and only if - the permanent product maps directly to a
                     stock product, this should refer to that product.
     """
-    productgroup = models.ForeignKey(ProductGroup, verbose_name=_('product group'))
+    productgroup = models.ForeignKey(ProductGroup, verbose_name=_('product group'), on_delete=models.SET_NULL, null=True)
     organization = models.ForeignKey(Organization, related_name='products', verbose_name=_('organization'))
     stockproduct = models.ForeignKey(StockProduct, verbose_name=_('stock product'), blank=True, null=True)
     position = models.IntegerField(verbose_name=_('position'))

--- a/apps/billing/models.py
+++ b/apps/billing/models.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
+from apps.billing.managers import TemporaryProductManager, PermanentProductManager
 from apps.scheduling.models import Event
 from apps.organization.models import Organization
 from apps.stock.models import StockProduct
@@ -165,6 +166,8 @@ class PermanentProduct(Product):
     stockproduct = models.ForeignKey(StockProduct, verbose_name=_('stock product'), blank=True, null=True)
     position = models.IntegerField(verbose_name=_('position'))
 
+    objects = PermanentProductManager()
+
     def is_permanent(self):
         return True
 
@@ -196,6 +199,8 @@ class TemporaryProduct(Product):
     """
     event = models.ForeignKey(Event, related_name='temporaryproducts', verbose_name=_('event'))
     price = models.DecimalField(_('price'), max_digits=15, decimal_places=2)
+
+    objects = TemporaryProductManager()
 
     def is_permanent(self):
         return True

--- a/apps/billing/models.py
+++ b/apps/billing/models.py
@@ -112,6 +112,7 @@ class Product(models.Model):
                                         help_text=_('Background color for Juliana'), max_length=6,
                                         validators=[RegexValidator(regex=r'^[0-9a-zA-Z]{6}$',
                                                                    message=_('Enter a valid hexadecimal color'))])
+    deleted = models.BooleanField(verbose_name=_("deleted"), default=False)
 
     @property
     def is_permanent(self):
@@ -122,6 +123,10 @@ class Product(models.Model):
     def is_temporary(self):
         """Indicates whether this is a TemporaryProduct"""
         return hasattr(self, 'temporaryproduct')
+
+    @property
+    def is_deleted(self):
+        return self.deleted
 
     def get_price(self, event):
         """Gets the price for a given event."""

--- a/apps/billing/urls.py
+++ b/apps/billing/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import patterns, url
 from apps.billing.views import PriceGroupListView, PriceGroupCreateView, PriceGroupDetailView, PriceGroupUpdateView, \
     ProductGroupListView, ProductGroupCreateView, ProductGroupDetailView, ProductGroupUpdateView, ProductRedirectView, \
     PermanentProductListView, PermanentProductCreateView, PermanentProductDetailView, PermanentProductUpdateView, \
+    PermanentProductDeleteView, TemporaryProductDeleteView, \
     TemporaryProductCreateView, TemporaryProductDetailView, TemporaryProductUpdateView, SellingPriceMatrixView, \
     SellingPriceCreateView, SellingPriceUpdateView, SellingPriceDeleteView
 
@@ -33,11 +34,15 @@ urlpatterns = patterns(
     url(r'^product/permanent/(?P<pk>\d+)/$', PermanentProductDetailView.as_view(), name='permanentproduct_detail'),
     url(r'^product/permanent/(?P<pk>\d+)/update/$', PermanentProductUpdateView.as_view(),
         name='permanentproduct_update'),
+    url(r'^product/permanent/(?P<pk>\d+)/delete/$', PermanentProductDeleteView.as_view(),
+        name='permanentproduct_delete'),
     url(r'^product/temporary/create/event/(?P<event_pk>\d+)/$', TemporaryProductCreateView.as_view(),
         name='temporaryproduct_create'),
     url(r'^product/temporary/(?P<pk>\d+)/$', TemporaryProductDetailView.as_view(), name='temporaryproduct_detail'),
     url(r'^product/temporary/(?P<pk>\d+)/update/$', TemporaryProductUpdateView.as_view(),
         name='temporaryproduct_update'),
+    url(r'^product/temporary/(?P<pk>\d+)/delete/$', TemporaryProductDeleteView.as_view(),
+        name='temporaryproduct_delete'),
 
     url(r'^sellingprice/matrix/$', SellingPriceMatrixView.as_view(), name='sellingprice_matrix'),
     url(r'^sellingprice/create/$', SellingPriceCreateView.as_view(), name='sellingprice_create'),

--- a/apps/billing/urls.py
+++ b/apps/billing/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import patterns, url
 
 from apps.billing.views import PriceGroupListView, PriceGroupCreateView, PriceGroupDetailView, PriceGroupUpdateView, \
-    ProductGroupListView, ProductGroupCreateView, ProductGroupDetailView, ProductGroupUpdateView, ProductRedirectView, \
+    ProductGroupListView, ProductGroupCreateView, ProductGroupDetailView, ProductGroupUpdateView, ProductGroupDeleteView, \
+    ProductRedirectView, \
     PermanentProductListView, PermanentProductCreateView, PermanentProductDetailView, PermanentProductUpdateView, \
     PermanentProductDeleteView, TemporaryProductDeleteView, \
     TemporaryProductCreateView, TemporaryProductDetailView, TemporaryProductUpdateView, SellingPriceMatrixView, \
@@ -25,6 +26,7 @@ urlpatterns = patterns(
     url(r'^productgroup/create/$', ProductGroupCreateView.as_view(), name='productgroup_create'),
     url(r'^productgroup/(?P<pk>\d+)/$', ProductGroupDetailView.as_view(), name='productgroup_detail'),
     url(r'^productgroup/(?P<pk>\d+)/update/$', ProductGroupUpdateView.as_view(), name='productgroup_update'),
+    url(r'^productgroup/(?P<pk>\d+)/delete/$', ProductGroupDeleteView.as_view(), name='productgroup_delete'),
 
     url(r'^product/(?P<pk>\d+)/$', ProductRedirectView.as_view(), name='product_detail'),
     url(r'^product/permanent/$', PermanentProductListView.as_view(), name='permanentproduct_list'),

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -137,6 +137,13 @@ class ProductGroupUpdateView(ManagerRequiredMixin, OrganizationFilterMixin, Cris
     fields = ['name']
 
 
+class ProductGroupDeleteView(ManagerRequiredMixin, OrganizationFilterMixin, CrispyFormMixin, DeleteView):
+    model = ProductGroup
+
+    def get_success_url(self):
+        return reverse('productgroup_list')
+
+
 class ProductRedirectView(ManagerRequiredMixin, SingleObjectMixin, RedirectView):
     """
     View to redirect to either the PermanentProductDetailView or the

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -1,7 +1,9 @@
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.urlresolvers import reverse
 from django.db.models import Count, Sum
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.views.generic.base import RedirectView, TemplateView
 from django.views.generic.detail import DetailView, SingleObjectMixin
@@ -191,6 +193,18 @@ class PermanentProductUpdateView(ManagerRequiredMixin, OrganizationFilterMixin, 
     form_class = PermanentProductForm
 
 
+class PermanentProductDeleteView(ManagerRequiredMixin, OrganizationFilterMixin, OrganizationFormMixin, CrispyFormMixin,
+                                 DeleteView):
+    model = PermanentProduct
+    template_name = "billing/product_confirm_delete.html"
+
+    def delete(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        self.object.deleted = True
+        self.object.save()
+        return HttpResponseRedirect(reverse('permanentproduct_list'))
+
+
 class TemporaryProductDetailView(ManagerRequiredMixin, EventOrganizerFilterMixin, DetailView):
     model = TemporaryProduct
 
@@ -207,6 +221,17 @@ class TemporaryProductCreateView(ManagerRequiredMixin, CrispyFormMixin, FixedVal
 class TemporaryProductUpdateView(ManagerRequiredMixin, EventOrganizerFilterMixin, CrispyFormMixin, UpdateView):
     model = TemporaryProduct
     fields = ['name', 'price', 'text_color', 'background_color']
+
+
+class TemporaryProductDeleteView(ManagerRequiredMixin, EventOrganizerFilterMixin, CrispyFormMixin, DeleteView):
+    model = TemporaryProduct
+    template_name = "billing/product_confirm_delete.html"
+
+    def delete(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        self.object.deleted = True
+        self.object.save()
+        return HttpResponseRedirect(self.object.event.get_absolute_url())
 
 
 class SellingPriceCreateView(ManagerRequiredMixin, OrganizationFormMixin, CrispyFormMixin, CreateView):

--- a/apps/organization/models.py
+++ b/apps/organization/models.py
@@ -80,6 +80,7 @@ class Profile(models.Model):
     def next_tending(self):
         return BartenderAvailability.objects.filter(
             user=self.user,
+            event__deleted=False,
             event__ends_at__gte=timezone.now(),
             availability__nature=Availability.ASSIGNED) \
             .order_by('event__starts_at')[0].event
@@ -152,6 +153,7 @@ class Profile(models.Model):
     def tended_count(self):
         return BartenderAvailability.objects.filter(
             user=self.user,
+            event__deleted=False,
             event__ends_at__lte=timezone.now(),
             availability__nature=Availability.ASSIGNED).count()
 
@@ -210,6 +212,7 @@ class Membership(models.Model):
     def tended(self):
         return BartenderAvailability.objects.filter(
             user=self.user,
+            event__deleted=False,
             event__ends_at__lte=timezone.now(),
             availability__nature=Availability.ASSIGNED). \
             order_by('-event__starts_at')

--- a/apps/scheduling/managers.py
+++ b/apps/scheduling/managers.py
@@ -6,6 +6,8 @@ from django.db.models.query_utils import Q
 
 class EventManager(models.Manager):
     """Provides several extra handy methods to find events."""
+    def get_queryset(self):
+        return super(EventManager, self).get_queryset().filter(deleted=False)
 
     def occuring_at(self, start, end):
         """Returns the events that occur (partially or entirely) between the

--- a/apps/scheduling/migrations/0009_event_deleted.py
+++ b/apps/scheduling/migrations/0009_event_deleted.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('scheduling', '0008_enrollclosed_mail'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='deleted',
+            field=models.BooleanField(default=False, verbose_name='deleted'),
+        ),
+    ]

--- a/apps/scheduling/models.py
+++ b/apps/scheduling/models.py
@@ -163,6 +163,7 @@ class Event(models.Model):
     """instructions for the bartenders"""
     is_risky = models.BooleanField(verbose_name=_("risky"), default=False)
     """whether this event is risky or not"""
+    deleted = models.BooleanField(verbose_name=_("deleted"), default=False)
 
     def get_absolute_url(self):
         return reverse('apps.scheduling.views.event_show', args=[self.pk])

--- a/apps/scheduling/perspectives.py
+++ b/apps/scheduling/perspectives.py
@@ -13,6 +13,7 @@ from .models import Event, Availability
 @tender_required
 def bartender(request):
     events = Event.objects.filter(ends_at__gte=timezone.now(),
+                                  deleted=False,
                                   bartender_availabilities__availability__nature=Availability.ASSIGNED,
                                   bartender_availabilities__user=request.user).order_by('starts_at')
 

--- a/apps/scheduling/views.py
+++ b/apps/scheduling/views.py
@@ -311,6 +311,7 @@ def personal_ical(request, ical_id):
     profile = get_object_or_404(Profile, ical_id=ical_id)
     bas = profile.user.bartender_availability_set.filter(
         availability__nature=Availability.ASSIGNED,
+        event__deleted=False,
         event__starts_at__gte=timezone.now() - timedelta(100)
     ). order_by('event__starts_at')
     events = []

--- a/apps/scheduling/views.py
+++ b/apps/scheduling/views.py
@@ -230,7 +230,8 @@ def event_delete(request, pk):
         raise PermissionDenied
 
     if request.method == 'POST':
-        event.delete()
+        event.deleted = True
+        event.save()
         log.event_deleted(request.user, event)
         return redirect(overview)
     else:

--- a/templates/billing/permanentproduct_list.html
+++ b/templates/billing/permanentproduct_list.html
@@ -40,6 +40,10 @@
                         <span class="glyphicon glyphicon-pencil"></span>
                         {% trans 'Modify' %}
                     </a>
+                    <a class="btn btn-xs btn-danger" href="{% url 'permanentproduct_delete' object.pk %}">
+                        <span class="glyphicon glyphicon-trash"></span>
+                        {% trans 'Delete' %}
+                    </a>
                 </td>
             </tr>
         {% empty %}

--- a/templates/billing/product_confirm_delete.html
+++ b/templates/billing/product_confirm_delete.html
@@ -1,0 +1,22 @@
+{% extends 'base_app.html' %}
+{% load i18n crispy_forms_tags %}
+
+{% block title %}{% blocktrans %}Delete product {{ object }}{% endblocktrans %}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1>{% blocktrans %}Delete product {{ object }}{% endblocktrans %}</h1>
+</div>
+<form method="post">
+    {% csrf_token %}
+    <p>
+        {% blocktrans %}Are you sure you want to delete product "{{ object }}"?{% endblocktrans %}
+    </p>
+    <div class="form-actions">
+        <button type="submit" class="btn btn-danger">
+            <span class="glyphicon glyphicon-trash"></span> {% trans 'Delete' %}
+        </button>
+        <a class="btn btn-default" href="{{ object.get_absolute_url }}">{% trans 'Cancel' %}</a>
+    </div>
+</form>
+{% endblock %}

--- a/templates/billing/productgroup_confirm_delete.html
+++ b/templates/billing/productgroup_confirm_delete.html
@@ -1,0 +1,22 @@
+{% extends 'base_app.html' %}
+{% load i18n crispy_forms_tags %}
+
+{% block title %}{% blocktrans %}Delete productgroup {{ object }}{% endblocktrans %}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1>{% blocktrans %}Delete productgroup {{ object }}{% endblocktrans %}</h1>
+</div>
+<form method="post">
+    {% csrf_token %}
+    <p>
+        {% blocktrans %}Are you sure you want to delete productgroup "{{ object }}"?{% endblocktrans %}
+    </p>
+    <div class="form-actions">
+        <button type="submit" class="btn btn-danger">
+            <span class="glyphicon glyphicon-trash"></span> {% trans 'Delete' %}
+        </button>
+        <a class="btn btn-default" href="{{ object.get_absolute_url }}">{% trans 'Cancel' %}</a>
+    </div>
+</form>
+{% endblock %}

--- a/templates/billing/productgroup_detail.html
+++ b/templates/billing/productgroup_detail.html
@@ -54,6 +54,10 @@
                                 <span class="glyphicon glyphicon-pencil"></span>
                                 {% trans 'Modify' %}
                             </a>
+                            <a class="btn btn-xs btn-danger" href="{% url 'permanentproduct_delete' permanentproduct.pk %}">
+                                <span class="glyphicon glyphicon-trash"></span>
+                                {% trans 'Delete' %}
+                            </a>
                         </td>
                     </tr>
                 {% empty %}

--- a/templates/billing/productgroup_list.html
+++ b/templates/billing/productgroup_list.html
@@ -32,6 +32,12 @@
                         <span class="glyphicon glyphicon-pencil"></span>
                         {% trans 'Modify' %}
                     </a>
+                    {% if object.permanentproduct_set.count == 0 %}
+                        <a class="btn btn-xs btn-danger" href="{% url 'productgroup_delete' object.pk %}">
+                            <span class="glyphicon glyphicon-trash"></span>
+                            {% trans 'Delete' %}
+                        </a>
+                    {% endif %}
                 </td>
             </tr>
         {% empty %}

--- a/templates/scheduling/event_show.html
+++ b/templates/scheduling/event_show.html
@@ -94,6 +94,10 @@
                                     <span class="glyphicon glyphicon-pencil"></span>
                                     {% trans 'Modify' %}
                                 </a>
+                               <a class="btn btn-danger btn-sm" href="{% url 'temporaryproduct_delete' temporaryproduct.pk %}">
+                                    <span class="glyphicon glyphicon-trash"></span>
+                                    {% trans 'Delete' %}
+                                </a>
                             </td>
                             {% endif %}
                         </tr>


### PR DESCRIPTION
This adds soft deletion for RFID cards and events, so that orders and purchases are never deleted. Not sure it'll be the best solution in the long-term, but we're using it for now, as it's better than the alternative. 
