### PR TITLE
Support marking tenders as inactive

### DIFF
--- a/apps/organization/forms.py
+++ b/apps/organization/forms.py
@@ -52,7 +52,7 @@ class MembershipAddForm(forms.Form):
 class MembershipEditForm(forms.ModelForm):
     class Meta:
         model = Membership
-        fields = ('is_tender', 'is_planner', 'is_manager', 'comments')
+        fields = ('is_active', 'is_tender', 'is_planner', 'is_manager', 'comments')
 
     helper = default_crispy_helper()
 

--- a/apps/organization/migrations/0010_membership_is_active.py
+++ b/apps/organization/migrations/0010_membership_is_active.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('organization', '0009_auto_20151122_2258'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='membership',
+            name='is_active',
+            field=models.BooleanField(default=True, verbose_name='is currently active'),
+        ),
+    ]

--- a/apps/organization/models.py
+++ b/apps/organization/models.py
@@ -191,6 +191,7 @@ class Membership(models.Model):
     is_tender = models.BooleanField(_('may tend on events'), default=False)
     is_planner = models.BooleanField(_('may create and modify events'), default=False)
     is_manager = models.BooleanField(_('may create and modify users'), default=False)
+    is_active = models.BooleanField(_('is currently active'), default=True)
 
     class Meta:
         ordering = ('user', 'organization')

--- a/apps/scheduling/management/commands/remindermail.py
+++ b/apps/scheduling/management/commands/remindermail.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         organizations = Organization.objects.filter(mailtemplate__name='reminder', mailtemplate__is_active=True)
 
         for organization in organizations:
-            memberships = organization.membership_set.filter(is_tender=True)
+            memberships = organization.membership_set.filter(is_tender=True, is_active=True)
 
             now = timezone.now()
             events = organization.participates.filter(starts_at__gte=now, is_closed=False).order_by('starts_at', )

--- a/apps/scheduling/tools.py
+++ b/apps/scheduling/tools.py
@@ -23,7 +23,7 @@ def notify_tenders(sender, instance, **kwargs):
             mt = MailTemplate.objects.get(organization=instance.organizer,
                                           name=mail_template)
             if mt.is_active:
-                members = instance.organizer.membership_set.filter(is_tender=True).exclude(user__email="")
+                members = instance.organizer.membership_set.filter(is_tender=True, is_active=True).exclude(user__email="")
                 addressees = [m.user for m in members]
                 mail(settings.EMAIL_FROM, addressees, mt.subject, mt.template, extraattrs={'event': instance})
         except MailTemplate.DoesNotExist:

--- a/apps/scheduling/views.py
+++ b/apps/scheduling/views.py
@@ -125,17 +125,21 @@ def event_show(request, pk):
     if is_planner:
         tenders = Membership.objects.select_related('user').filter(
             organization__in=event.participants.all(), is_tender=True). \
-            order_by("user__first_name")
+            order_by("is_active", "user__first_name")
         bas = collections.defaultdict(list)
 
         for ba in BartenderAvailability.objects.select_related().filter(event=event):
             bas[ba.user].append(ba)
 
-        availabilities = []
+        active_availabilities = []
+        inactive_availabilities = []
         for t in tenders:
             ba = bas[t.user]
             a = ba[0].availability if ba else None
-            availabilities.append(dict({'user': t.user, 'availability': a}))
+            if t.is_active:
+                active_availabilities.append(dict({'user': t.user, 'availability': a}))
+            else:
+                inactive_availabilities.append(dict({'user': t.user, 'availability': a}))
 
     return render(request, 'scheduling/event_show.html', locals())
 

--- a/templates/membership/list.html
+++ b/templates/membership/list.html
@@ -24,6 +24,7 @@
                 <th>#</th>
                 <th>{% trans 'Name' %}</th>
                 <th>{% trans 'Authorization' %}</th>
+                <th>{% trans 'Active' %}</th>
                 <th>{% trans 'IVA' %}</th>
                 <th>{% trans 'Tended' %}</th>
                 <th>{% trans 'Last tended' %}</th>
@@ -40,6 +41,13 @@
                     {% if membership.is_tender %}<span class="label label-default">{% trans 'Bartender' %}</span>{% endif %}
                     {% if membership.is_planner %}<span class="label label-default">{% trans 'Planner' %}</span>{% endif %}
                     {% if membership.is_manager %}<span class="label label-default">{% trans 'Manager' %}</span>{% endif %}
+                </td>
+                <td>
+                    {% if membership.is_active %}
+                        <span class="icon-alexia-ok"></span>
+                    {% else %}
+                        <span class="icon-alexia-notok"></span>
+                    {% endif %}
                 </td>
                 <td>
                     {% if membership.user.profile.has_iva %}

--- a/templates/scheduling/event_show.html
+++ b/templates/scheduling/event_show.html
@@ -112,18 +112,13 @@
         <div class="col-xs-12 col-sm-6">
             <h3>{% trans 'Bartenders' %}</h3>
             <table class="table table-condensed">
-                {% for a in availabilities %}
-                <tr>
-                    <td>{{ a.user.get_full_name }}</td>
-                    <td>
-                        <a href="{% url 'apps.scheduling.views.event_edit_bartender_availability' pk=event.pk user_pk=a.user.pk %}">
-                            <span class="label label-{{ a.availability.css_class|default:'default' }}">{{ a.availability|default:_("Unknown") }}</span>
-                        </a>
-                    </td>
-                </tr>
-                </tr>
-                {% endfor %}
+                {% include 'scheduling/partials/tender_availabilities.html' with tenders=active_availabilities %}
             </table>
+
+            {% if inactive_availabilities %}
+                <h4>{% trans 'Inactive bartenders' %}</h4>
+                {% include 'scheduling/partials/tender_availabilities.html' with tenders=inactive_availabilities %}
+            {% endif %}
         </div>
     {% endif %}
 </div>

--- a/templates/scheduling/partials/tender_availabilities.html
+++ b/templates/scheduling/partials/tender_availabilities.html
@@ -1,0 +1,12 @@
+<table class="table table-condensed">
+    {% for a in tenders %}
+    <tr>
+        <td>{{ a.user.get_full_name }}</td>
+        <td>
+            <a href="{% url 'apps.scheduling.views.event_edit_bartender_availability' pk=event.pk user_pk=a.user.pk %}">
+                <span class="label label-{{ a.availability.css_class|default:'default' }}">{{ a.availability|default:_("Unknown") }}</span>
+            </a>
+        </td>
+    </tr>
+    {% endfor %}
+</table>


### PR DESCRIPTION
Tenders who are inactive (for example because they are currently doing an internship and out of the country) can be marked. They don't receive notification mails and show up in the availability list under a separate heading. 