### PR TITLE
Show payments grouped per event on profile

### DIFF
--- a/apps/profile/urls.py
+++ b/apps/profile/urls.py
@@ -8,5 +8,6 @@ urlpatterns = patterns(
     url(r'^edit/$', 'edit'),
     url(r'^iva/$', 'iva'),
     url(r'^view_iva/$', 'view_iva'),
-    url(r'^payments/$', 'payments'),
+    url(r'^expenditures/$', 'expenditures'),
+    url(r'^expenditures/(?P<pk>\d+)/$', 'expenditures_event')
 )

--- a/templates/profile/expenditures.html
+++ b/templates/profile/expenditures.html
@@ -1,0 +1,43 @@
+{% extends 'base_app.html' %}
+{% load i18n crispy_forms_tags %}
+
+{% block title %}{% trans 'My expenditures' %}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1>
+        {% trans 'My expenditures' %}
+    </h1>
+</div>
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>{% trans 'Date' %}</th>
+                <th>{% trans 'Event' %}</th>
+                <th>{% trans 'Amount spent' %}</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for e in events %}
+            <tr>
+                <td>{{ e.starts_at|date:"l d F" }}</td>
+                <td>{{ e.name }}</td>
+                <td>&euro; {{ e.spent|floatformat:2 }}</td>
+                <td><a href="{% url 'apps.profile.views.expenditures_event' e.pk %}" class="btn btn-xs btn-default">Details</a></td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="4">{% trans 'There are no expenditures!' %}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+<p class="text-center">
+    {% if events.has_previous %}<a href="?page={{ events.previous_page_number }}">&laquo;</a>{% else %}&laquo;{% endif %}
+    {% trans 'Page' %} {{ events.number }} {% trans 'of' %} {{ events.paginator.num_pages }}
+    {% if events.has_next     %}<a href="?page={{ events.next_page_number }}">&raquo;</a>{%     else %}&raquo;{% endif %}
+</p>
+{% endblock %}

--- a/templates/profile/expenditures_event.html
+++ b/templates/profile/expenditures_event.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="page-header">
     <h1>
-        {% trans 'My payments' %}
+        {% blocktrans %}My payments at {{ event }}{% endblocktrans %}
     </h1>
 </div>
 <div class="table-responsive">
@@ -14,7 +14,6 @@
         <thead>
             <tr>
                 <th>{% trans 'Timestamp' %}</th>
-                <th>{% trans 'Event' %}</th>
                 <th>{% trans 'Amount' %}</th>
                 <th>{% trans 'Handled by' %}</th>
                 <th></th>
@@ -24,7 +23,6 @@
         {% for o in orders %}
             <tr>
                 <td>{{ o.placed_at|date:"l d F H:i" }}</td>
-                <td>{{ o.event }}</td>
                 <td>&euro; {{ o.amount|floatformat:2 }}</td>
                 <td>{{ o.added_by.get_full_name }}</td>
                 <td><a href="{% url 'apps.billing.views.payment_show' o.pk %}" class="btn btn-xs btn-default">Details</a></td>

--- a/templates/profile/index.html
+++ b/templates/profile/index.html
@@ -20,6 +20,7 @@
         <table class="table table-bordered">
             <tr class="tr-muted"><th>{% trans 'Stats' %}</th></tr>
             <tr><td class="text-right"><strong class="pull-left">{% trans 'Transactions' %}</strong> {{ order_count }}</td></tr>
+            <tr><td class="text-right"><strong class="pull-left">{% trans 'Events attended' %}</strong> {{ event_count }}</td></tr>
             {% if user.profile.is_tender %}<tr><td class="text-right"><strong class="pull-left">{% trans 'Tended' %}</strong> {{ user.profile.tended_count }}</td></tr>{% endif %}
         </table>
     </div>
@@ -32,29 +33,25 @@
             <div class="tab-pane active" id="billing">
                 <div class="row">
                     <div class="col-xs-12 col-lg-6">
-                        <h4>{% trans 'Transactions' %}</h4>
+                        <h4>{% trans 'Events' %}</h4>
                         <p>
-                            {% trans 'These are your last 5 payments.' %}
-                            <a href="{% url 'apps.profile.views.payments' %}">{% trans 'See all' %}...</a>
+                            {% trans 'These are the last 5 events you attended.' %}
+                            <a href="{% url 'apps.profile.views.expenditures' %}">{% trans 'See all' %}...</a>
                         </p>
                         <table class="table table-striped table-bordered">
                             <thead>
                                 <tr>
                                     <th>{% trans 'Event' %}</th>
-                                    <th>{% trans 'Time' %}</th>
-                                    <th>{% trans 'Amount' %}</th>
+                                    <th>{% trans 'Spent' %}</th>
+                                    <th></th>
                                 </tr>
                             </thead>
                             <tbody>
-                            {% for o in orders %}
+                            {% for e in events %}
                                 <tr>
-                                    <td>{{ o.event }}</td>
-                                    <td>{{ o.placed_at|date:"H:i" }}</td>
-                                    <td>&euro; {{ o.amount|floatformat:2 }}</td>
-                                </tr>            
-                            {% empty %}
-                                <tr>
-                                    <td colspan="3">{% trans 'There are no transactions.' %}</td>
+                                    <td>{{ e.name }}</td>
+                                    <td>&euro; {{ e.spent|floatformat:2 }}</td>
+                                    <td><a href="{% url 'apps.profile.views.expenditures_event' e.pk %}" class="btn btn-xs btn-default">Details</a></td>
                                 </tr>
                             {% endfor %}
                             </tbody>


### PR DESCRIPTION
Show payments grouped per event on users' profile. This is useful as it gives a total price per event, which is usually a lot more interesting than the separate payments (which can still be viewed).