### PR TITLE
Split percentage of orders out in food and drinks

### DIFF
--- a/apps/billing/forms.py
+++ b/apps/billing/forms.py
@@ -16,7 +16,7 @@ class PermanentProductForm(ModelForm):
 
     class Meta:
         model = PermanentProduct
-        fields = ['name', 'productgroup', 'stockproduct', 'position', 'text_color', 'background_color']
+        fields = ['name', 'productgroup', 'stockproduct', 'position', 'text_color', 'background_color', 'is_food']
 
 
 class SellingPriceForm(ModelForm):

--- a/apps/billing/migrations/0012_product_is_food.py
+++ b/apps/billing/migrations/0012_product_is_food.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('billing', '0011_alter_order_purchase'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='product',
+            name='is_food',
+            field=models.BooleanField(default=False, verbose_name='Is food?'),
+        ),
+    ]

--- a/apps/billing/models.py
+++ b/apps/billing/models.py
@@ -112,6 +112,7 @@ class Product(models.Model):
                                         help_text=_('Background color for Juliana'), max_length=6,
                                         validators=[RegexValidator(regex=r'^[0-9a-zA-Z]{6}$',
                                                                    message=_('Enter a valid hexadecimal color'))])
+    is_food = models.BooleanField(verbose_name=_('Is food?'), default=False)
 
     @property
     def is_permanent(self):

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -197,7 +197,7 @@ class TemporaryProductDetailView(ManagerRequiredMixin, EventOrganizerFilterMixin
 
 class TemporaryProductCreateView(ManagerRequiredMixin, CrispyFormMixin, FixedValueCreateView):
     model = TemporaryProduct
-    fields = ['name', 'price', 'text_color', 'background_color']
+    fields = ['name', 'price', 'text_color', 'background_color', 'is_food']
 
     def get_instance(self):
         event = get_object_or_404(Event, pk=self.kwargs['event_pk'])

--- a/templates/billing/permanentproduct_detail.html
+++ b/templates/billing/permanentproduct_detail.html
@@ -27,6 +27,10 @@
                 <th>{% trans 'Stock product' %}</th>
                 <td>{{ object.stockproduct|default_if_none:"&mdash;" }}</td>
             </tr>
+            <tr>
+                <th>{% trans 'Food' %}</th>
+                <td>{{ object.is_food|yesno }}</td>
+            </tr>
         </table>
         <p>
             <a class="btn btn-default" href="{% url 'permanentproduct_update' object.pk %}">

--- a/templates/billing/temporaryproduct_detail.html
+++ b/templates/billing/temporaryproduct_detail.html
@@ -23,6 +23,10 @@
                 <th>{% trans 'Price' %}</th>
                 <td>&euro; {{ object.price }}</td>
             </tr>
+            <tr>
+                <th>{% trans 'Food' %}</th>
+                <td>{{ object.is_food|yesno }}</td>
+            </tr>
         </table>
         <p>
             <a class="btn btn-default" href="{% url 'temporaryproduct_update' object.pk %}">

--- a/templates/profile/index.html
+++ b/templates/profile/index.html
@@ -103,14 +103,16 @@
                             <thead>
                                 <tr>
                                     <th>{% trans 'Organization' %}</th>
-                                    <th>{% trans 'Share' %}</th>
+                                    <th>{% trans 'Food' %}</th>
+                                    <th>{% trans 'Drinks' %}</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {% for share in shares %}
                                 <tr>
                                     <td>{{ share.organization }}</td>
-                                    <td>{{ share.percentage }}%</td>
+                                    <td>{{ share.food }}%</td>
+                                    <td>{{ share.drinks }}%</td>
                                 </tr>
                                 {% endfor %}
                             </tbody>


### PR DESCRIPTION
Selling food through the system biases the percentage of revenue a lot towards those who eat at events, so split them out. 
