### PR TITLE
Event softdelete

### DIFF
--- a/apps/organization/models.py
+++ b/apps/organization/models.py
@@ -86,6 +86,7 @@ class Profile(models.Model):
     def next_tending(self):
         return BartenderAvailability.objects.filter(
             user=self.user,
+            event__is_deleted=False,
             event__ends_at__gte=timezone.now(),
             availability__nature=Availability.ASSIGNED,
         ).order_by('event__starts_at')[0].event
@@ -149,6 +150,7 @@ class Profile(models.Model):
     def tended_count(self):
         return BartenderAvailability.objects.filter(
             user=self.user,
+            event__is_deleted=False,
             event__ends_at__lte=timezone.now(),
             availability__nature=Availability.ASSIGNED,
         ).count()
@@ -225,6 +227,7 @@ class Membership(models.Model):
     def tended(self):
         return BartenderAvailability.objects.filter(
             user=self.user,
+            event__is_deleted=False,
             event__ends_at__lte=timezone.now(),
             availability__nature=Availability.ASSIGNED
         ).order_by('-event__starts_at')

--- a/apps/scheduling/managers.py
+++ b/apps/scheduling/managers.py
@@ -7,6 +7,18 @@ from django.db.models.query_utils import Q
 class EventManager(models.Manager):
     """Provides several extra handy methods to find events."""
 
+    def get_queryset(self):
+        """
+        Return only active events by default
+        """
+        return super(EventManager, self).get_queryset().filter(is_deleted=False)
+
+    def all_events(self):
+        """
+        Return all events, including deleted ones
+        """
+        return super(EventManager, self).get_queryset()
+
     def occuring_at(self, start, end):
         """Returns the events that occur (partially or entirely) between the
         given start and end datetimes.

--- a/apps/scheduling/models.py
+++ b/apps/scheduling/models.py
@@ -144,6 +144,7 @@ class Event(models.Model):
             'Designates that this event should be marked as risky.'
         ),
     )
+    is_deleted = models.BooleanField(verbose_name=_("is deleted"), default=False)
 
     objects = EventManager()
 

--- a/apps/scheduling/views.py
+++ b/apps/scheduling/views.py
@@ -249,7 +249,8 @@ def event_delete(request, pk):
         raise PermissionDenied
 
     if request.method == 'POST':
-        event.delete()
+        event.is_deleted = True
+        event.save()
         log.event_deleted(request.user, event)
         return redirect(overview)
     else:

--- a/apps/scheduling/views.py
+++ b/apps/scheduling/views.py
@@ -330,6 +330,7 @@ def personal_ical(request, ical_id):
     profile = get_object_or_404(Profile, ical_id=ical_id)
     bas = profile.user.bartender_availability_set.filter(
         availability__nature=Availability.ASSIGNED,
+        event__is_deleted=False,
         event__starts_at__gte=timezone.now() - timedelta(100)
     ). order_by('event__starts_at')
     events = []


### PR DESCRIPTION
Allows events to be soft-deleted. Soft-deleted events do not count in tenders' statistics and do not show up where lists of events are shown. All events (including deleted ones) can be retrieved using Event.objects.all_events().

Replaces the softdelete part of events of PR #12.