### PR TITLE
Expand Alexia API to include some methods for GDPR-compliance

### DIFF
--- a/alexia/api/v1/common.py
+++ b/alexia/api/v1/common.py
@@ -1,4 +1,6 @@
-from alexia.apps.organization.models import AuthenticationData
+import base64
+
+from alexia.apps.organization.models import AuthenticationData, Certificate
 from alexia.auth.backends import RADIUS_BACKEND_NAME
 
 
@@ -73,4 +75,18 @@ def format_user(user):
         'first_name': user.first_name,
         'last_name': user.last_name,
         'authentication_data': auth_data
+    }
+
+
+def format_certificate(certificate):
+    """
+
+    :type certificate: alexia.apps.organization.models.Certificate
+    """
+    with open(certificate.file.path, "rb") as certificate_file:
+        certificate_b64 = base64.b64encode(certificate_file.read())
+
+    return {
+        'user': certificate.owner.username,
+        'certificate_data': certificate_b64.decode("utf-8")
     }

--- a/alexia/api/v1/methods/__init__.py
+++ b/alexia/api/v1/methods/__init__.py
@@ -6,3 +6,4 @@ from .juliana import *  # NOQA
 from .organization import *  # NOQA
 from .rfid import *  # NOQA
 from .user import *  # NOQA
+from .scheduling import *  # NOQA

--- a/alexia/api/v1/methods/billing.py
+++ b/alexia/api/v1/methods/billing.py
@@ -156,7 +156,7 @@ def order_list(request, radius_username):
 
     Returns an array of orders.
 
-    radius_username -- (optional) RADUIS username to search for.
+    radius_username -- RADUIS username to search for.
 
     Example return value:
     [

--- a/alexia/api/v1/methods/billing.py
+++ b/alexia/api/v1/methods/billing.py
@@ -4,6 +4,7 @@ from jsonrpc import jsonrpc_method
 from alexia.api.decorators import manager_required
 from alexia.api.exceptions import InvalidParamsError, ObjectNotFoundError
 from alexia.apps.billing.models import Order
+from alexia.auth.backends import RADIUS_BACKEND_NAME
 
 from ..common import format_order
 from ..config import api_v1_site
@@ -141,6 +142,89 @@ def order_get(request, order_id):
         raise ObjectNotFoundError
 
     return format_order(order)
+
+
+@jsonrpc_method('order.list(radius_username=String) -> Array', site=api_v1_site, safe=True, authenticated=True)
+@manager_required
+def order_list(request, radius_username):
+    """
+    Retrieve a list of orders for the currently selected organization.
+
+    Required user level: Manager
+
+    Povide radius_username to select only orders made by the provided user.
+
+    Returns an array of orders.
+
+    radius_username -- (optional) RADUIS username to search for.
+
+    Example return value:
+    [
+        {
+            "purchases": [
+                {
+                    "price": "1.00",
+                    "product": {"name": "Coca Cola"},
+                    "amount": 2
+                }, {
+                    "price": "0.50",
+                    "product": {"name": "Grolsch"},
+                    "amount": 1
+                }
+            ],
+            "synchronized": false,
+            "event": {
+                "id": 4210,
+                "name": "Testborrel"
+            },
+            "placed_at": "2015-03-11T15:24:06+00:00",
+            "id": 1255,
+            "rfid": "02,06:65:74:49",
+            "authorization": {
+                "id": 1,
+                "end_date": null,
+                "start_date": "2014-09-21T14:16:06+00:00",
+                "user": "s0000000"
+            }
+        },
+        {
+            "purchases": [
+                {
+                    "price": "1.50",
+                    "product": {"name": "Grolsch"},
+                    "amount": 3
+                }
+            ],
+            "synchronized": true,
+            "event": {
+                "id": 4210,
+                "name": "Testborrel"
+            },
+            "placed_at": "2015-03-11T16:47:21+00:00",
+            "id": 1271,
+            "rfid": "02,06:65:74:49",
+            "authorization": {
+                "id": 1,
+                "end_date": null,
+                "start_date": "2014-09-21T14:16:06+00:00",
+                "user": "s0000000"
+            }
+        }
+    ]
+    """
+    result = []
+    orders = Order.objects.filter(event__organizer=request.organization)
+
+    if radius_username is not None:
+        orders = orders.filter(authorization__user__authenticationdata__backend=RADIUS_BACKEND_NAME,
+                               authorization__user__authenticationdata__username=radius_username)
+
+    orders = orders.select_related('event', 'authorization')
+
+    for order in orders:
+        result.append(format_order(order))
+
+    return result
 
 
 @jsonrpc_method('order.marksynchronized(order_id=Number) -> Boolean', site=api_v1_site, authenticated=True)

--- a/alexia/api/v1/methods/scheduling.py
+++ b/alexia/api/v1/methods/scheduling.py
@@ -1,0 +1,57 @@
+from jsonrpc import jsonrpc_method
+
+from alexia.api.decorators import manager_required
+from alexia.api.exceptions import ObjectNotFoundError
+from alexia.apps.scheduling.models import BartenderAvailability
+from alexia.auth.backends import User, RADIUS_BACKEND_NAME
+
+from ..config import api_v1_site
+
+
+@jsonrpc_method('user.get_availabilities(radius_username=String) -> Array', site=api_v1_site, safe=True, authenticated=True)
+@manager_required
+def user_get_availabilities(request, radius_username):
+    """
+    Retrieve the availabilities entered by a specific user for the current organization.
+
+    Required user level: Manager
+
+    radius_username     -- RADIUS username to search for.
+
+    Raises error 404 if the specified user does not exist.
+
+    Example result value:
+    [
+        {
+            "event": {
+                "name": "Test Drink",
+                "date": "2017-09-12T14:00:00Z",
+
+            },
+            "availability": "Yes"
+        },
+        {
+            "event": {
+                "name": "Test Drink 2",
+                "date": "2017-09-18T16:00:00Z",
+
+            },
+            "availability": "Maybe"
+        }
+    ]
+    """
+    try:
+        user = User.objects.get(authenticationdata__backend=RADIUS_BACKEND_NAME,
+                                authenticationdata__username=radius_username)
+    except User.DoesNotExist:
+        raise ObjectNotFoundError
+
+    availabilities = BartenderAvailability.objects.filter(user=user, event__organizer=request.organization)
+
+    return [{
+        "event": {
+            "name": availability.event.name,
+            "date": availability.event.starts_at
+        },
+        "availability": availability.availability.name
+    } for availability in availabilities]

--- a/alexia/api/v1/methods/user.py
+++ b/alexia/api/v1/methods/user.py
@@ -4,10 +4,10 @@ from jsonrpc import jsonrpc_method
 
 from alexia.api.decorators import manager_required
 from alexia.api.exceptions import InvalidParamsError, ObjectNotFoundError
-from alexia.apps.organization.models import AuthenticationData, Profile
+from alexia.apps.organization.models import AuthenticationData, Profile, Certificate, Membership
 from alexia.auth.backends import RADIUS_BACKEND_NAME
 
-from ..common import format_user
+from ..common import format_user, format_certificate
 from ..config import api_v1_site
 
 
@@ -116,3 +116,83 @@ def user_get_by_id(request, user_id):
         raise ObjectNotFoundError
 
     return format_user(user)
+
+
+@jsonrpc_method('user.get_membership(radius_username=String) -> Object', site=api_v1_site, safe=True, authenticated=True)
+@manager_required
+def user_get_membership(request, radius_username):
+    """
+    Retrieve the membership details for a specific user for the current organization.
+
+    Required user level: Manager
+
+    radius_username     -- RADIUS username to search for.
+
+    Raises error 404 if the provided username cannot be found or the user has no membership with the current organization.
+
+    Example result value:
+    {
+        "user": "s0000000",
+        "organization": "Inter-Actief",
+        "comments": "",
+        "is_tender": True,
+        "is_planner": False,
+        "is_manager": False,
+        "is_active": True
+    }
+    """
+    try:
+        user = User.objects.get(authenticationdata__backend=RADIUS_BACKEND_NAME,
+                                authenticationdata__username=radius_username)
+    except User.DoesNotExist:
+        raise ObjectNotFoundError
+
+    try:
+        membership = Membership.objects.get(
+            user=user,
+            organization=request.organization
+        )
+    except Membership.DoesNotExist:
+        raise ObjectNotFoundError
+
+    return {
+        "user": user.username,
+        "organization": request.organization.name,
+        "comments": membership.comments,
+        "is_tender": membership.is_tender,
+        "is_planner": membership.is_planner,
+        "is_manager": membership.is_manager,
+        "is_active": membership.is_active
+    }
+
+
+@jsonrpc_method('user.get_iva_certificate(radius_username=String) -> Object', site=api_v1_site, safe=True, authenticated=True)
+@manager_required
+def user_get_iva_certificate(request, radius_username):
+    """
+    Retrieve the IVA certificate file for a specific user.
+
+    Required user level: Manager
+
+    radius_username    -- RADIUS username to search for.
+
+    Raises error 404 if provided username cannot be found or the user has no IVA certificate.
+
+    Example result value:
+    {
+        "user": "s0000000",
+        "certificate_data": "U29tZSBiYXNlIDY0IHRleHQgdGhhdCBtaWdodCBiZ.........BhIGxvdCBsb25nZXIgdGhhbiB0aGlzIGlzLi4u"
+    }
+    """
+    try:
+        user = User.objects.get(authenticationdata__backend=RADIUS_BACKEND_NAME,
+                                authenticationdata__username=radius_username)
+    except User.DoesNotExist:
+        raise ObjectNotFoundError
+
+    try:
+        certificate = Certificate.objects.get(owner=user)
+    except Certificate.DoesNotExist:
+        raise ObjectNotFoundError
+
+    return format_certificate(certificate)


### PR DESCRIPTION
These methods will mostly be used by Inter-Actief's website to facilitate that users are able to request a data-export of all their user data. Because this also includes personal data stored in other systems, and we want to provide a single place to create this export, we need a way to export this information from Alexia.