### PR TITLE
Add email address to user representation to include it in the API exports

### DIFF
--- a/alexia/api/v1/common.py
+++ b/alexia/api/v1/common.py
@@ -74,7 +74,8 @@ def format_user(user):
         'radius_username': user_name,
         'first_name': user.first_name,
         'last_name': user.last_name,
-        'authentication_data': auth_data
+        'authentication_data': auth_data,
+        'email_address': user.email
     }
 
 


### PR DESCRIPTION
The email address can be changed by the person on alexia itself so
it might be different then the address in the organization's system.
Thus, it needs to be exported as it is personal data.