### PR TITLE
Add option to include ongoing events in the API

### DIFF
--- a/alexia/api/v1/methods/event.py
+++ b/alexia/api/v1/methods/event.py
@@ -6,14 +6,16 @@ from alexia.apps.scheduling.models import Event
 from ..config import api_v1_site
 
 
-@jsonrpc_method('event.upcoming_list() -> Array', site=api_v1_site, safe=True)
-def upcoming_events_list(request):
+@jsonrpc_method('event.upcoming_list(include_ongoing=Boolean) -> Array', site=api_v1_site, safe=True)
+def upcoming_events_list(request, include_ongoing=False):
     """
-    List all upcoming events.
+    List all current and upcoming events.
 
     Required user level: None
 
-    Returns a array with zero or more events.
+    include_current -- Whether to include ongoing events, defaults to false
+
+    Returns an array with zero or more events.
 
     Example output:
     [{
@@ -27,6 +29,7 @@ def upcoming_events_list(request):
         'is_risky': false,
     }]
     """
+    filter_key = 'ends_at__gte' if include_ongoing else 'starts_at__gte'
     return [{
                 'name': e.name,
                 'locations': [l.name for l in e.location.all()],
@@ -36,4 +39,4 @@ def upcoming_events_list(request):
                 'ends_at': e.ends_at,
                 'kegs': e.kegs,
                 'is_risky': e.is_risky,
-            } for e in Event.objects.filter(starts_at__gte=timezone.now())]
+            } for e in Event.objects.filter(**{filter_key: timezone.now()})]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ eventlog==0.11.0
 icalendar==4.0.7
 jsonfield<3.1.0
 pyrad==2.4
-git+git://github.com/samuraisam/django-json-rpc@a88d744d960e828f3eb21265da0f10a694b8ebcf
-git+git://github.com/Inter-Actief/django-sslserver@389a4e42dba5a9b3ca1f3a4013044e07a52dc43c
+git+https://github.com/samuraisam/django-json-rpc@a88d744d960e828f3eb21265da0f10a694b8ebcf
+git+https://github.com/Inter-Actief/django-sslserver@389a4e42dba5a9b3ca1f3a4013044e07a52dc43c
 # SAML SP (requires xmlsec and libssl-dev (on Debian))
 djangosaml2>=0.50.0,<0.51
 raven==6.10.0


### PR DESCRIPTION
Also changes git URLs to https because GitHub stopped supporting the former.

Tested locally and confirmed to be working. Addresses part of #62.