### PR TITLE
Update Juliana to support new JulianaNFC-Python 3.x release

### DIFF
--- a/assets/js/juliana.js
+++ b/assets/js/juliana.js
@@ -110,15 +110,7 @@ State = {
 Scanner = {
     init: function () {
         var scanner = this;
-        var socket;
-
-        if (Settings.androidapp) {
-            // Juliana app on Android will not connect if a protocol is specified
-            socket = new WebSocket('ws://localhost:3000');
-        } else {
-            // JulianaNFC_C application on Windows will not connect without nfc protocol
-            socket = new WebSocket('ws://localhost:3000', 'nfc');
-        }
+        var socket = new WebSocket('ws://localhost:3000');
 
         socket.onopen = function (event) {
             console.log('Connected with websocket!');


### PR DESCRIPTION
This PR updates the Juliana NFC websocket code to support the new [JulianaNFC-Python 3.x](https://github.com/Inter-Actief/JulianaNFC_Python/releases) release on windows and linux on all browsers.

NOTE! - If this is merged, the old JulianaNFC_C v2 will probably not work any more with Alexia, due to the connection parameter change. Associations that make use of the NFC functionality of Alexia should be notified that they need to update the JulianaNFC client application to the new version after this is merged. The Syscom of Inter-Actief can update the Juliana client on the drink room PCs.